### PR TITLE
docs(kubectl): how to push profiles to profefe

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ The profiles are stored inside your `/tmp` directory (you can change it with
 ```
 go tool pprof /tmp/profile-goroutine-influxdb-v2-1575552135.pb.gz
 ```
+
+If you have a profefe up and running you can push your profiles there other than
+locally:
+
+```
+kubectl profefe capture influxdb-v2 --profefe-hostport http://localhost:10100
+```


### PR DESCRIPTION
Added a chapter about how to push profiles in profefe from
`kubectl profefe capture` command.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>