### PR TITLE
feat: add dependabot

### DIFF
--- a/.dependabot/config.yaml
+++ b/.dependabot/config.yaml
@@ -1,0 +1,6 @@
+version: 1
+update_configs:
+    -
+        package_manager: 'go:modules'
+        directory: /
+        update_schedule: daily


### PR DESCRIPTION
Dependabot is a nice GitHub bot that helps maintainer to keep
dependencies up to date.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>