### PR TITLE
fix: the binary name for kube-profefe should be kubectl

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ before:
 builds:
 - id: "kubectl-profefe"
   main: ./cmd/kubectl-profefe
+  binary: kubectl-profefe
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
The binary inside a release was not right, it needs to be
`kubectl-profefe`

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>