### PR TITLE
feat(kubectl): add get commands

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+
+	cmd.AddCommand(NewGetProfilesCmd())
+	cmd.AddCommand(NewGetProfileTypesCmd())
+	return cmd
+}

--- a/pkg/cmd/get_profile_types.go
+++ b/pkg/cmd/get_profile_types.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/gianarb/kube-profefe/pkg/profefe"
+	"github.com/spf13/cobra"
+)
+
+func NewGetProfileTypesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile-types",
+		Short: "Retrieve supported profile types",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, v := range profefe.AllProfileTypes() {
+				println(v)
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/pkg/cmd/get_profiles.go
+++ b/pkg/cmd/get_profiles.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gianarb/kube-profefe/pkg/profefe"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	service     string
+	profileType string
+	from        time.Duration
+	to          time.Duration
+)
+
+func NewGetProfilesCmd() *cobra.Command {
+	flags := pflag.NewFlagSet("kprofefe", pflag.ExitOnError)
+
+	cmd := &cobra.Command{
+		Use:   "profiles",
+		Short: "Retrieve profiles from profefe",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			pClient := profefe.NewClient(profefe.Config{
+				HostPort: ProfefeHostPort,
+			}, http.Client{})
+
+			req := profefe.GetProfilesRequest{}
+			req.Service = service
+
+			if profileType != "" {
+				pt := profefe.NewProfileTypeFromString(profileType)
+				if pt != profefe.UnknownProfile {
+					req.Type = pt
+				}
+			}
+
+			req.To = time.Now()
+			req.From = req.To.Add(-from)
+
+			resp, err := pClient.GetProfiles(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			for _, v := range resp.Body {
+				println(fmt.Sprintf("ID: %s Type: %s Service: %s CreateAt: %s", v.ID, v.Type, v.Service, v.CreatedAt.Format(time.RFC1123)))
+			}
+			return nil
+		},
+	}
+
+	flags.AddFlagSet(cmd.PersistentFlags())
+	flags.StringVar(&ProfefeHostPort, "profefe-hostport", "http://localhost:10100", `where profefe is located`)
+	flags.StringVar(&profileType, "profile-type", "cpu", `The pprof profiles to retrieve`)
+	flags.StringVar(&service, "service", "", ``)
+	flags.DurationVar(&from, "from", 24*time.Hour, ``)
+	flags.DurationVar(&to, "to", 0, ``)
+
+	cmd.Flags().AddFlagSet(flags)
+
+	return cmd
+}

--- a/pkg/cmd/profefe.go
+++ b/pkg/cmd/profefe.go
@@ -39,6 +39,7 @@ func NewProfefeCmd(streams genericclioptions.IOStreams) *cobra.Command {
 	flagsCapture.StringVar(&OutputDir, "output-dir", "/tmp", "Directory where to place the profiles")
 	captureCmd.Flags().AddFlagSet(flagsCapture)
 	rootCmd.AddCommand(captureCmd)
+	rootCmd.AddCommand(NewGetCmd())
 
 	return rootCmd
 }


### PR DESCRIPTION
Now you can do `kubectl get`:

* profiles: to retrieve profiles
* profile-types: to retrieve the list of supported profiles

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>