### PR TITLE
fix(kprofefe): the output when a profile get stored in profefe is wrong

### DIFF
--- a/pkg/cmd/kprofefe.go
+++ b/pkg/cmd/kprofefe.go
@@ -165,7 +165,7 @@ func do(ctx context.Context, l *zap.Logger, pClient *profefe.Client, target core
 		if err != nil {
 			logger.Warn("Unknown profile type it can not be sent to profefe. Skip this profile", zap.Error(err))
 		} else {
-			logger.Info("Profile stored in profefe.", zap.String("id", saved.Body.ID), zap.String("profefe_profile_type", profefeType.String()), zap.String("url", fmt.Sprintf("%s/api/0/profiles/%s type=%s", ProfefeHostPort, saved.Body.ID, profefeType)))
+			logger.Info("Profile stored in profefe.", zap.String("id", saved.Body.ID), zap.String("profefe_profile_type", profefeType.String()), zap.String("url", fmt.Sprintf("%s/api/0/profiles/%s", ProfefeHostPort, saved.Body.ID)))
 		}
 	}
 }


### PR DESCRIPTION
When a profile gets pushed to profefe we log a URL to easy lookup but
the output was wrong because we was printing the profile type as well

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>