### PR TITLE
feat(kubectl): Add new kubectl command "get profiles" 

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -13,5 +13,6 @@ func NewGetCmd() *cobra.Command {
 
 	cmd.AddCommand(NewGetProfilesCmd())
 	cmd.AddCommand(NewGetProfileTypesCmd())
+	cmd.AddCommand(NewGetServicesCmd())
 	return cmd
 }

--- a/pkg/cmd/get_services.go
+++ b/pkg/cmd/get_services.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gianarb/kube-profefe/pkg/profefe"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func NewGetServicesCmd() *cobra.Command {
+	flags := pflag.NewFlagSet("kprofefe", pflag.ExitOnError)
+
+	cmd := &cobra.Command{
+		Use: "services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			pClient := profefe.NewClient(profefe.Config{
+				HostPort: ProfefeHostPort,
+			}, http.Client{})
+
+			resp, err := pClient.GetServices(ctx)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), "Services:\n")
+			for _, v := range resp.Body {
+				fmt.Fprintf(cmd.OutOrStdout(), "\t %s\n", v)
+			}
+			return nil
+		},
+	}
+
+	flags.AddFlagSet(cmd.PersistentFlags())
+	flags.StringVar(&ProfefeHostPort, "profefe-hostport", "http://localhost:10100", `where profefe is located`)
+
+	cmd.Flags().AddFlagSet(flags)
+
+	return cmd
+}

--- a/pkg/cmd/get_services_test.go
+++ b/pkg/cmd/get_services_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGetServices(t *testing.T) {
+	pprofServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte(`{
+  "code": 200,
+  "body": [
+    "first",
+    "second"
+  ]
+}`))
+	}))
+
+	buf := new(bytes.Buffer)
+	cmd := NewGetServicesCmd()
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{
+		"--profefe-hostport",
+		pprofServer.URL,
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp := `Services:
+     first
+     second`
+
+	out := buf.String()
+	if strings.Contains(out, exp) {
+		t.Errorf(`expected "%s" got "%s"`, exp, out)
+	}
+}
+
+//Services:
+//first
+//second

--- a/pkg/profefe/client.go
+++ b/pkg/profefe/client.go
@@ -244,6 +244,31 @@ type SavePprofResponse struct {
 	} `json:"body"`
 }
 
+// GET
+// /api/0/services
+func (c *Client) GetServices(ctx context.Context) (*GetServicesResponse, error) {
+	buf := bytes.NewBuffer([]byte{})
+	r, err := http.NewRequestWithContext(ctx, "GET", c.HostPort+"/api/0/services", buf)
+
+	resp, err := c.Do(r)
+	defer resp.Body.Close()
+	rr := &GetServicesResponse{}
+
+	err = json.NewDecoder(resp.Body).Decode(rr)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return rr, nil
+	}
+	return nil, fmt.Errorf(rr.Error)
+}
+
+type GetServicesResponse struct {
+	Body  []string
+	Error string `json:"error"`
+}
+
 func NewClient(config Config, httpClient http.Client) *Client {
 	if config.HostPort == "" {
 		config.HostPort = "http://localhost:10100"


### PR DESCRIPTION
Fixed #27

This PR adds a new command that prints the list of services currently
stored in profefe.

```
$ kubectl get services
Services:
     frontend
     backend
```

Co-Authored-by: All-watchers-on-Twitch  <hello@whoknows.internet>
Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>