### PR TITLE
fix(kubectl): krew action does not work

### DIFF
--- a/.krew/profefe.yaml
+++ b/.krew/profefe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: profefe
 spec:
-  version: { { .TagName } }
+  version: {{ .TagName }}
   homepage: https://github.com/profefe/kube-profefe
   shortDescription: Gather and manage pprof profiles from running pods
   description: |
@@ -16,8 +16,7 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/profefe/kube-profefe/releases/download/{{ .TagName }}/kube-profefe_{{ .TagName }}_Darwin_x86_64.tar.gz"
-      sha256: a2dd151fcaf3b7e4341986c6cc2726e0dccc69d634fc96a0ac97f8b03ad930a5
+      {{addURIAndSha "https://github.com/profefe/kube-profefe/releases/download/{{ .TagName }}/kube-profefe_{{ .TagName }}_Darwin_x86_64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-profefe
       files:
         - from: kubectl-profefe
@@ -28,8 +27,7 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/profefe/kube-profefe/releases/download/{{ .TagName }}/kube-profefe_{{ .TagName }}_Linux_x86_64.tar.gz"
-      sha256: b68479389df557dd29abd42268fdd9fc22b522a1dfe97458bfb5f804da1f6445
+      {{addURIAndSha "https://github.com/profefe/kube-profefe/releases/download/{{ .TagName }}/kube-profefe_{{ .TagName }}_Linux_x86_64.tar.gz" .TagName | indent 6 }}
       bin: kubectl-profefe
       files:
         - from: kubectl-profefe


### PR DESCRIPTION
The currently deployed release workflow does not work. The template file
for krew does not get translated correctly.

This is an attempt to fix this issue

```
11:42 $ docker run -v $PWD/.krew/profefe.yaml:/tmp/template-file.yaml rajatjindal/krew-release-bot:v0.0.37   krew-release-bot template --tag v0.3.0 --template-file /tmp/template-file.yaml > /tmp/ciao
time="2020-04-05T09:43:35Z" level=info msg="getting sha256 for https://github.com/profefe/kube-profefe/releases/download/v0.3.0/kube-profefe_v0.3.0_Darwin_x86_64.tar.gz"
time="2020-04-05T09:44:03Z" level=info msg="downloaded file /tmp/266050939/1586079815"
time="2020-04-05T09:44:03Z" level=info msg="getting sha256 for https://github.com/profefe/kube-profefe/releases/download/v0.3.0/kube-profefe_v0.3.0_Linux_x86_64.tar.gz"
time="2020-04-05T09:44:40Z" level=info msg="downloaded file /tmp/965187230/1586079843"
time="2020-04-05T09:44:40Z" level=fatal msg="failed to get plugin name from processed template.\nerr: error converting YAML to JSON: yaml: line 19: did not find expected '-' indicator"

```

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>