### PR TITLE
docs: remove newline in bref so hugo build can pass

### DIFF
--- a/docs/content/docs/developing.md
+++ b/docs/content/docs/developing.md
@@ -4,8 +4,7 @@ description = "Contributing to kube-profefe"
 weight = 30
 draft = false
 toc = true
-bref = "An overview of the kube-profefe delivery and testing toolchain for
-contributors"
+bref = "An overview of the kube-profefe delivery and testing toolchain for contributors"
 +++
 
 This project is written in Go and it uses [go


### PR DESCRIPTION
Looks like the last github actions build failed because I included a newline in the bref field. I tested this with `hugo --minify --environment=production` locally to ensure that it will build this time